### PR TITLE
fix data_crawler DATA_DIR to work in a module

### DIFF
--- a/corona_ts/data_utils/data_crawler.py
+++ b/corona_ts/data_utils/data_crawler.py
@@ -6,7 +6,8 @@ import urllib.request
 import pandas as pd
 from task_geo.data_sources import get_data_source
 
-DATA_DIR = Path(__file__).parent.parent.parent / "data"
+#DATA_DIR = Path(__file__).parent.parent.parent / "data"
+DATA_DIR = Path.cwd().parent / "data"
 
 
 def fetch_time_series() -> pd.DataFrame:


### PR DESCRIPTION
addresses the issue of having DATA_DIR pointing inside python modules system folder instead of to some "data" folder inside user space. 

Current fix works within coronawhy/airflow-ts image